### PR TITLE
Rewritten gkeyring-as

### DIFF
--- a/auto.smb.gnomekeyring
+++ b/auto.smb.gnomekeyring
@@ -26,6 +26,23 @@
 # If all methods fail, the script will try to obtain the list
 # of shares anonymously.
 
+# Use special AUTOFS_* variables if set
+if [ ! -z $AUTOFS_UID ]; then
+  export UID=$AUTOFS_UID
+fi
+if [ ! -z $AUTOFS_GID ]; then
+  export GID=$AUTOFS_GID
+fi
+if [ ! -z $AUTOFS_USER ]; then
+  export USER=$AUTOFS_USER
+fi
+if [ ! -z $AUTOFS_HOME ]; then
+  export HOME=$AUTOFS_HOME
+fi
+if [ ! -z $AUTOFS_SHOST ]; then
+  export SHOST=$AUTOFS_SHOST
+fi
+
 get_keyring_cred() {
 		kr_creds=
 

--- a/auto.smb.gnomekeyring
+++ b/auto.smb.gnomekeyring
@@ -27,8 +27,9 @@
 # of shares anonymously.
 
 # Use special AUTOFS_* variables if set
+_UID=$UID
 if [ ! -z $AUTOFS_UID ]; then
-  export UID=$AUTOFS_UID
+  export _UID=$AUTOFS_UID
 fi
 if [ ! -z $AUTOFS_GID ]; then
   export GID=$AUTOFS_GID
@@ -64,7 +65,7 @@ get_keyring_cred() {
 
 get_krb5_cache() {
     cache=
-    uid=${UID}
+    uid=${_UID}
     for x in $(ls -d /run/user/$uid/krb5cc_* 2>/dev/null); do
         if [ -d "$x" ] && klist -s DIR:"$x"; then
 	    cache=DIR:$x
@@ -95,12 +96,12 @@ done
 
 creds=/etc/creds/$key
 if [ -f "$creds" ]; then
-    opts="$opts"',uid=$UID,gid=$GID,credentials='"$creds"
+    opts="$opts"',uid=$_UID,gid=$GID,credentials='"$creds"
     smbopts="-A $creds"
 else
     get_krb5_cache
     if [ -n "$cache" ]; then
-        opts="$opts"',multiuser,cruid=$UID,sec=krb5i'
+        opts="$opts"',multiuser,cruid=$_UID,sec=krb5i'
         smbopts="-k"
         export KRB5CCNAME=$cache
     else
@@ -110,7 +111,7 @@ else
 						KR_DOMAIN=$(echo "$kr_creds" | cut -f2)
 						KR_PASS=$(echo "$kr_creds" |  cut -f3)
 						
-	 					opts="${opts},uid=$UID,gid=$GID"
+	 					opts="${opts},uid=$_UID,gid=$GID"
 						if [ -n "$KR_USER" ]; then
 								opts="${opts},username=$KR_USER"
 								smbopts="${smbopts} --user=${KR_USER}"

--- a/gkeyring-as
+++ b/gkeyring-as
@@ -29,51 +29,42 @@ if [ ! -x "$GKEYRING" ]; then
 		exit 2;
 fi
 
-# find getent in standard locations
+# find pgrep in standard locations
 for P in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 do
-		if [ -x $P/getent ]
+		if [ -x $P/pgrep ]
 		then
-				GETENT=$P/getent
+				PGREP=$P/pgrep
 				break
 		fi
 done
 
-if [ ! -x "$GETENT" ]; then
-		echo "getent not found" >&2;
+if [ ! -x "$PGREP" ]; then
+		echo "pgrep not found" >&2;
 		exit 2;
 fi
 
-# validate username 
-as_user="$1"
-as_user_passwd=$(${GETENT} passwd "${as_user}")
-if [ ! -n "${as_user_passwd}" ]; then
-		echo "User ${as_user} does not exist" >&2;
-		exit 3
-else
-		if [ "${as_user}" != "${as_user_passwd%%:*}" ]; then
-				echo "User ${as_user} does not exist" >&2;
-				exit 4
-		fi
-fi
-
 # remove username from parameter list
+as_user="$1"
 shift
 
+# Find pid of running gnome-keyring daemon for the given user
+krpid=$( $PGREP -f "gnome-keyring-daemon" -u "$as_user" -o )
+if [ -z $krpid ]; then
+  echo "gnome-keyring-daemon not running for user $as_user"
+  exit 3
+fi
+
+dbusaddress=$( cat /proc/$krpid/environ | grep -z "^DBUS_SESSION_BUS_ADDRESS=" | tr -d "\000" )
+if [ -z $dbusaddress ]; then
+  echo "unable to determine DBUS_SESSION_BUS_ADDRESS for user $USER"
+  exit 4
+fi
+
+
 exec su "${as_user}" <<EOF
-  # find users Session DBUS address
-  DBUS_SESSIONFILE="\${HOME}/.dbus/session-bus/$(cat /var/lib/dbus/machine-id)-0"
-
-  if [ -f "\${DBUS_SESSIONFILE}" ]; then
-    source "\${DBUS_SESSIONFILE}"
-    export DBUS_SESSION_BUS_ADDRESS
-  else
-    echo "No Session DBus found" >&2
-    exit 5
-  fi
-
   # run gkeyring
-  $GKEYRING $@
+  $dbusaddress $GKEYRING $@
 EOF
 
 


### PR DESCRIPTION
Hello,
unfortunately, gkeyring-as did not work anymore after I switched to debian stretch with latest gnome-session. The .dbus is completely missing in my home directory.
But I found a much more reliable way to get the dbus session bus addess: If you know at least one process that is connected to the dbus, you can fetch it's environment vars and get the address from there. I use th process gnome-keyring-daemon which is required to run to get a password from the keyring.
